### PR TITLE
feat(ttvisual): add proxy support for image src

### DIFF
--- a/lib/TTVisual/components/TTVisualImage.tsx
+++ b/lib/TTVisual/components/TTVisualImage.tsx
@@ -4,11 +4,14 @@ import { Element } from 'slate'
 export const TTVisualImage = ({ children, rootNode }: Plugin.ComponentProps): JSX.Element => {
   const { properties = { href: '' } } = Element.isElement(rootNode) ? rootNode : {}
   const href = properties.href as string
+  // Property added either when adding a tt/visual or when transforming
+  // This volatile and will only be added to the collaborative state, _not_ persisted.
+  const proxy = properties.proxy as string
 
   return (
     <div contentEditable={false} draggable={false}>
       <div className='overflow-hidden bg-gray-100'>
-        <img width='100%' src={href} className='max-h-96 object-contain' />
+        <img width='100%' src={proxy || href} className='max-h-96 object-contain' />
       </div>
       {children}
     </div>

--- a/lib/TTVisual/lib/consume.ts
+++ b/lib/TTVisual/lib/consume.ts
@@ -31,6 +31,7 @@ const createTTVisualNode = async (input: Plugin.Resource): Promise<Plugin.Resour
       type: 'tt/visual',
       properties: {
         href: props.href,
+        proxy: props.proxy,
         uri: `http://tt.se/media/image/${parseImageId(props.href)}`,
         rel: props.rel || 'self',
         text: props.text,

--- a/lib/TTVisual/types.ts
+++ b/lib/TTVisual/types.ts
@@ -2,6 +2,7 @@ export interface VisualPropertiesInterface {
   byline: string
   text: string
   href: string
+  proxy?: string
   uri: string
   rel?: string
   height: number


### PR DESCRIPTION
Add optional `proxy` property to visual image nodes and types. The image component now uses the `proxy` URL for the image source if available, falling back to the original `href`. This allows for collaborative or transient image proxying without persisting the proxy URL.