### PR TITLE
feat(factbox): split body text into separate nodes

### DIFF
--- a/lib/Factbox/components/Factbox.tsx
+++ b/lib/Factbox/components/Factbox.tsx
@@ -5,6 +5,8 @@ import { FactboxHeaderItem } from './FactboxHeaderItem'
 import { type Descendant, Transforms } from 'slate'
 import { FocusBlock } from '../../components/FocusBlock'
 
+const MESSAGE = 'Ändringar i faktarutans text sker endast för denna artikel'
+
 export const Factbox = ({ children, element, options, editor }: Plugin.ComponentProps): JSX.Element => {
   const original_updated = element?.properties?.original_updated ?? ''
   const original_id = element?.properties?.original_id
@@ -19,7 +21,7 @@ export const Factbox = ({ children, element, options, editor }: Plugin.Component
           onMouseDown={(e) => { e.stopPropagation() }}
         >
           <FactboxHeaderItem
-            title='Ändringar i artikelns faktarutas text sker endast i denna artikel.'
+            title={MESSAGE}
             icon={{
               icon: MessageCircleWarning,
               className: 'text-red-800'
@@ -73,7 +75,7 @@ export const Factbox = ({ children, element, options, editor }: Plugin.Component
 
 
         <div contentEditable={false} className='flex items-center gap-2 text-xs text-red-800 m-1 p-2 bg-slate-100 rounded-sm px-2 py-1'>
-          Ändringar i artikelns faktarutas text sker endast i denna artikel.
+          {MESSAGE}
         </div>
       </div>
     </FocusBlock>

--- a/lib/Factbox/lib/consume.ts
+++ b/lib/Factbox/lib/consume.ts
@@ -28,17 +28,17 @@ const createFactboxNode = (input: Plugin.Resource): Plugin.Resource => {
     locally_changed
   } = JSON.parse(input.data as string)
 
-  const body = text
-    .split('\n')
-    .map((t: string) => ({
-     type: 'core/factbox/body',
-     class: 'text',
-     children: [{
+  const body = {
+    type: 'core/factbox/body',
+    class: 'text',
+    children: text
+      .split('\n')
+      .map((t: string) => ({
        type: 'core/text',
        class: 'text',
        children: [{ text: t }]
-     }]
-  }))
+     }))
+    }
 
   return {
     ...input,
@@ -64,7 +64,7 @@ const createFactboxNode = (input: Plugin.Resource): Plugin.Resource => {
           class: 'text',
           children: [{ text: title }]
         },
-        ...body
+        body
       ]
     }
   }

--- a/lib/Factbox/lib/consume.ts
+++ b/lib/Factbox/lib/consume.ts
@@ -14,11 +14,31 @@ export const consume: Plugin.ConsumeFunction = async ({ input }) => {
 
 /**
 * Create a Factbox node
-* @param {FactboxInterface} input
-* @returns {FactboxInterface}
+* @param {Plugin.Resource} input
+* @returns {Plugin.Resource}
 */
 const createFactboxNode = (input: Plugin.Resource): Plugin.Resource => {
-  const { text, title, modified, id, original_version, original_updated, locally_changed } = JSON.parse(input.data as string)
+  const { 
+    text, 
+    title, 
+    modified, 
+    id, 
+    original_version, 
+    original_updated, 
+    locally_changed
+  } = JSON.parse(input.data as string)
+
+  const body = text
+    .split('\n')
+    .map((t: string) => ({
+     type: 'core/factbox/body',
+     class: 'text',
+     children: [{
+       type: 'core/text',
+       class: 'text',
+       children: [{ text: t }]
+     }]
+  }))
 
   return {
     ...input,
@@ -44,15 +64,7 @@ const createFactboxNode = (input: Plugin.Resource): Plugin.Resource => {
           class: 'text',
           children: [{ text: title }]
         },
-        {
-          type: 'core/factbox/body',
-          class: 'text',
-          children: [{
-            type: 'core/text',
-            class: 'text',
-            children: [{ text: text }]
-          }]
-        }
+        ...body
       ]
     }
   }

--- a/tests/Factbox/consume.test.ts
+++ b/tests/Factbox/consume.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { consume } from '../../lib/Factbox/lib/consume'
+import { Plugin } from '@ttab/textbit'
+import { Editor } from 'slate'
+
+describe('Factbox consume', () => {
+  const validInput: Plugin.Resource = {
+    data: JSON.stringify({
+      text: 'Factbox line 1\nFactbox line 2',
+      title: 'Factbox Title',
+      modified: '2024-01-01T00:00:00Z',
+      id: 'factbox-123',
+      original_version: 1,
+      original_updated: '2024-01-01T00:00:00Z',
+      locally_changed: false
+    }),
+    type: 'core/factbox',
+    source: ''
+  }
+
+  it('throws if input is an array', async () => {
+    await expect(consume({ input: [validInput], editor: {} as Editor })).rejects.toThrow(
+      /expected string for consumation, not a list/
+    )
+  })
+
+  it('throws if input.data is not a string', async () => {
+    await expect(consume({ input: { ...validInput, data: 123 }, editor: {} as Editor })).rejects.toThrow(
+      /expected string for consumation/
+    )
+  })
+
+  it('returns a valid factbox node', async () => {
+    const result = await consume({ input: validInput, editor: {} as Editor })
+    if (!result?.data) {
+      throw new Error('No data returned from consume')
+    }
+
+    const data = result.data as any
+
+    expect(data).toBeDefined()
+    expect(result.type).toBe('core/factbox')
+    expect(data.class).toBe('block')
+    expect(data.properties.title).toBe('Factbox Title')
+    expect(data.properties.text).toBe('Factbox line 1\nFactbox line 2')
+    expect(data.children[0].type).toBe('core/factbox/title')
+    expect(data.children[1].type).toBe('core/factbox/body')
+    expect(data.children[1].children.length).toBe(2)
+    expect(data.children[1].children[0].children[0].text).toBe('Factbox line 1')
+    expect(data.children[1].children[1].children[0].text).toBe('Factbox line 2')
+  })
+})

--- a/tests/Factbox/consumes.test.ts
+++ b/tests/Factbox/consumes.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { consumes } from '../../lib/Factbox/lib/consumes'
+
+describe('Factbox plugin consumer', () => {
+  it('should consume core/factbox', async () => {
+    const resource = {
+      input: {
+        source: '',
+        type: 'core/factbox',
+        data: ''
+      }
+    }
+
+    expect(consumes(resource)).toEqual([true, 'core/factbox'])
+  })
+})


### PR DESCRIPTION
Refactor the Factbox node creation to split the body text by newlines, creating a separate 'core/factbox/body' node for each line. This improves the structure and rendering of multiline factbox content.