### PR TITLE
feat: upgrade @ttab/textbit to v0.22.0 and update stats usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^14.5.2",
-        "@ttab/textbit": "^0.21.7",
+        "@ttab/textbit": "^0.22.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.13.4",
         "@types/react": "^18.3.9",
@@ -47,7 +47,7 @@
         "vitest": "^3.0.5"
       },
       "peerDependencies": {
-        "@ttab/textbit": "^0.21.7",
+        "@ttab/textbit": "^0.22.0",
         "lucide-react": "^0.475.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2250,16 +2250,16 @@
       "dev": true
     },
     "node_modules/@ttab/textbit": {
-      "version": "0.21.7",
-      "resolved": "https://npm.pkg.github.com/download/@ttab/textbit/0.21.7/4a01f2537fa360c5612208a301b168e97df96728",
-      "integrity": "sha512-Nn7+BbjW6RRnU+wy17vpzRgN/JGbRZFNWYKYeosk3VOgl/0ObQ0+ta1gJzrMdt97B0ri0PAy+PQL7fQndK2IFg==",
+      "version": "0.22.0",
+      "resolved": "https://npm.pkg.github.com/download/@ttab/textbit/0.22.0/63edbecbc9f23a8c4dccdb51074deec5342d15c0",
+      "integrity": "sha512-A2Sy31HyUgEBpotn4rMsQFdcpCDPcl19og8MfyGoSNP7WNfvtZbBBXNZWdRua8rgYhHr+g1JmoBsdqB0QceUXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@slate-yjs/react": "^1.1.0",
         "is-hotkey": "^0.2.0",
         "is-url": "^1.2.4",
-        "slate": "^0.110.2",
+        "slate": "^0.112.0",
         "slate-history": "^0.110.3",
         "slate-hyperscript": "^0.100.0",
         "slate-react": "^0.112.1",
@@ -2268,17 +2268,6 @@
       "peerDependencies": {
         "@slate-yjs/core": "^1.0.2",
         "react": "^18.3.1"
-      }
-    },
-    "node_modules/@ttab/textbit/node_modules/slate": {
-      "version": "0.110.2",
-      "resolved": "https://registry.npmjs.org/slate/-/slate-0.110.2.tgz",
-      "integrity": "sha512-4xGULnyMCiEQ0Ml7JAC1A6HVE6MNpPJU7Eq4cXh1LxlrR0dFXC3XC+rNfQtUJ7chHoPkws57x7DDiWiZAt+PBA==",
-      "dev": true,
-      "dependencies": {
-        "immer": "^10.0.3",
-        "is-plain-object": "^5.0.0",
-        "tiny-warning": "^1.0.3"
       }
     },
     "node_modules/@types/argparse": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "postversion": "git push && git push --tags"
   },
   "peerDependencies": {
-    "@ttab/textbit": "^0.21.7",
+    "@ttab/textbit": "^0.22.0",
     "lucide-react": "^0.475.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -54,7 +54,7 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.5.2",
-    "@ttab/textbit": "^0.21.7",
+    "@ttab/textbit": "^0.22.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.13.4",
     "@types/react": "^18.3.9",

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -87,15 +87,15 @@ function Editor({ initialValue }: {
   initialValue: Descendant[]
 }): JSX.Element {
   const [value, setValue] = useState<Descendant[]>(initialValue)
-  const { characters, words } = useTextbit()
+  const { stats } = useTextbit()
 
   return (
     <div className="mr-12">
       <div className="flex items-center justify-between font-sans text-sm gap-4 ml-14 py-4 mb-2 border-b">
         <ThemeSwitcher />
         <div className="flex items-end gap-4">
-          <div> Words: {words}</div>
-          <div> Characters: {characters}</div>
+          <div>{` Words: ${stats.short.words} (${stats.full.words})`}</div>
+          <div>{` Characters: ${stats.short.characters} (${stats.full.characters})`}</div>
         </div>
       </div>
       <Textbit.Editable


### PR DESCRIPTION
Upgraded @ttab/textbit to version 0.22.0 in dependencies and peerDependencies. Changed usage of text statistics in Editor component to use the new `stats` object, displaying both short and full counts for words and characters.