### PR TITLE
Ring around is moved into Textbit with block caret support

### DIFF
--- a/lib/Blockquote/components/Blockquote.tsx
+++ b/lib/Blockquote/components/Blockquote.tsx
@@ -1,12 +1,12 @@
 import type { TBComponentProps } from '@ttab/textbit'
-import { FocusBlock } from '../../components/FocusBlock'
+import { Block } from '../../components/FocusBlock'
 
 export const Blockquote = ({ children }: TBComponentProps) => {
   return (
-    <FocusBlock className='my-2'>
+    <Block className='my-2'>
       <div className='px-6 py-4 border-l-8 border-l-slate-200 group-data-[state="active"]:rounded'>
         {children}
       </div>
-    </FocusBlock>
+    </Block>
   )
 }

--- a/lib/Factbox/components/Factbox.tsx
+++ b/lib/Factbox/components/Factbox.tsx
@@ -3,7 +3,7 @@ import { FilePen, MessageCircleWarning, SaveIcon, X } from 'lucide-react'
 import { FactboxModified } from './FactboxModified'
 import { FactboxHeaderItem } from './FactboxHeaderItem'
 import { type Descendant, Transforms } from 'slate'
-import { FocusBlock } from '../../components/FocusBlock'
+import { Block } from '../../components/FocusBlock'
 
 export const Factbox = ({ children, element, options, editor }: TBComponentProps) => {
   const originalUpdated = element?.properties?.original_updated ?? ''
@@ -30,7 +30,7 @@ export const Factbox = ({ children, element, options, editor }: TBComponentProps
   const UNSAVED_MESSAGE = unsavedLabel ?? 'Factbox has not been saved to archive'
 
   return (
-    <FocusBlock className='my-2'>
+    <Block className='my-2'>
       <div className='group border-2 rounded border-slate-200'>
         <div
           contentEditable={false}
@@ -130,6 +130,6 @@ export const Factbox = ({ children, element, options, editor }: TBComponentProps
           {MESSAGE}
         </div>
       </div>
-    </FocusBlock>
+    </Block>
   )
 }

--- a/lib/Image/components/Figure.tsx
+++ b/lib/Image/components/Figure.tsx
@@ -1,12 +1,12 @@
 import type { TBComponentProps } from '@ttab/textbit'
-import { FocusBlock } from '../../components/FocusBlock'
+import { Block } from '../../components/FocusBlock'
 
 export const Figure = ({ children }: TBComponentProps) => {
   return (
-    <FocusBlock className='my-2'>
+    <Block className='my-2'>
       <figure className="flex gap-1 flex-col min-h-10 rounded-sm">
         {children}
       </figure>
-    </FocusBlock>
+    </Block>
   )
 }

--- a/lib/OEmbed/components/OembedWrapper.tsx
+++ b/lib/OEmbed/components/OembedWrapper.tsx
@@ -1,12 +1,12 @@
 import type { TBComponentProps } from '@ttab/textbit'
-import { FocusBlock } from '../../components/FocusBlock'
+import { Block } from '../../components/FocusBlock'
 
 export const OembedWrapper = ({ children }: TBComponentProps) => {
   return (
-    <FocusBlock className='my-2'>
+    <Block className='my-2'>
       <div className="flex gap-1 flex-col py-2 min-h-10 rounded-sm">
         {children}
       </div>
-    </FocusBlock>
+    </Block>
   )
 }

--- a/lib/TTVisual/components/TTVisualWrapper.tsx
+++ b/lib/TTVisual/components/TTVisualWrapper.tsx
@@ -3,7 +3,7 @@ import type { TBComponentProps } from '@ttab/textbit'
 import { X } from 'lucide-react'
 import { cn } from '../../cn'
 import { type Descendant, Transforms } from 'slate'
-import { FocusBlock } from '../../components/FocusBlock'
+import { Block } from '../../components/FocusBlock'
 
 type Child = React.ReactElement & {
   props: { children: { props: { element: { type: string } } } }
@@ -36,7 +36,7 @@ export const TTVisualWrapper = ({ children, element, editor, options }: TBCompon
   })
 
   return (
-    <FocusBlock className='my-2'>
+    <Block className='my-2'>
       <figure className='relative group flex gap-1 flex-col min-h-10'>
         {removable && (
           <div contentEditable={false} className='absolute hidden right-1 top-2 size-8 w-fit text-slate-900 dark:text-white justify-between items-center group-hover:block z-50'>
@@ -70,6 +70,6 @@ export const TTVisualWrapper = ({ children, element, editor, options }: TBCompon
           </div>
         ))}
       </figure>
-    </FocusBlock>
+    </Block>
   )
 }

--- a/lib/Table/components/Table.tsx
+++ b/lib/Table/components/Table.tsx
@@ -1,14 +1,14 @@
 import type { TBComponentProps } from '@ttab/textbit'
-import { FocusBlock } from '../../components/FocusBlock'
+import { Block } from '../../components/FocusBlock'
 
 export const Table = (props: TBComponentProps) => {
   return (
-    <FocusBlock className='my-2'>
+    <Block className='my-2'>
       <table className='w-full border table-fixed border-separate rounded border-spacing-0 m-0 p-0'>
         <tbody>
           {props.children}
         </tbody>
       </table>
-    </FocusBlock>
+    </Block>
   )
 }

--- a/lib/components/FocusBlock.tsx
+++ b/lib/components/FocusBlock.tsx
@@ -1,15 +1,11 @@
 import type { PropsWithChildren } from 'react'
-import { cn } from '../cn'
 
-export const FocusBlock = ({ children, className }: PropsWithChildren & {
+export const Block = ({ children, className }: PropsWithChildren & {
   className?: string
 }) => {
   return (
-    <div className={cn('relative', className)}>
-      <div contentEditable={false} className='absolute inset-0 rounded pointer-events-none ring-offset-4 group-data-[state="active"]:rounded group-data-[state="active"]:ring-1' />
-      <div className='relative rounded'>
-        {children}
-      </div>
+    <div className={className}>
+      {children}
     </div>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
-        "@ttab/textbit": "^1.0.15",
+        "@ttab/textbit": "^1.1.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "tailwind-merge": "^3.0.2"
@@ -2281,9 +2281,9 @@
       "license": "MIT"
     },
     "node_modules/@ttab/textbit": {
-      "version": "1.0.15",
-      "resolved": "https://npm.pkg.github.com/download/@ttab/textbit/1.0.15/88ee976e55a1f756167022aa93f595211a8323c3",
-      "integrity": "sha512-4HRtbt2P+CohlBlcaTk9A3W4PQRrKnB2HGFX2u9zBN3/wELbHG1x8P0YBkFazg3d8S0w7G7+7tNhcsLCqDb/0g==",
+      "version": "1.1.0",
+      "resolved": "https://npm.pkg.github.com/download/@ttab/textbit/1.1.0/bafdc05d5abbd093c151e6900fe2c80ea5c35b34",
+      "integrity": "sha512-fziOQ4wlb8xj+V43WE6trvh5A16xWKHERFM+SpUoiPaUEt53jLC+tVSssxgnUwlQZSp2h4P1rrpfxxzxnLRJhQ==",
       "license": "MIT",
       "dependencies": {
         "is-hotkey": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "yjs": "^13.6.26"
   },
   "dependencies": {
-    "@ttab/textbit": "^1.0.15",
+    "@ttab/textbit": "^1.1.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "tailwind-merge": "^3.0.2"


### PR DESCRIPTION
Needed for https://github.com/ttab/textbit/pull/339 to work inside elephant-chrome.