### PR TITLE
Fix LocalizedQuotationMarks for text nested deeper than one block

### DIFF
--- a/lib/LocalizedQuotationMarks/lib/consume.ts
+++ b/lib/LocalizedQuotationMarks/lib/consume.ts
@@ -106,14 +106,19 @@ export const consume: TBConsumeFunction = async ({ editor, input }) => {
   }
 
 
-  const basePos = selection.anchor.path[0] // Position of basenode in editor
+  // Iterate the sibling text leaves of the current text node. The current
+  // text node lives at selection.anchor.path; its parent block is the path
+  // with the last index dropped. Hard-coding depth 2 here fails when the
+  // text is nested deeper, e.g. inside a factbox embedded in an article.
+  const parentPath = Path.parent(selection.anchor.path)
+  const startIndex = selection.anchor.path[selection.anchor.path.length - 1]
   let firstOffset = selection.anchor.offset // Start text offset in first node
   let point // We will store the point of found quote, then traverse 2 more chars
   let prevChar: string = '' // We will keep track of the char that comes after the current char
 
   // From anchor inline node and backwards
-  for (let pos = selection.anchor.path[1]; pos >= 0; pos--) {
-    const [node, path] = Editor.node(editor, [basePos, pos])
+  for (let pos = startIndex; pos >= 0; pos--) {
+    const [node, path] = Editor.node(editor, [...parentPath, pos])
     if (!Text.isText(node)) {
       continue
     }
@@ -191,8 +196,11 @@ function isFirstCharacterOfFirstChild(editor: Editor, selection: BaseRange): boo
     return false
   }
 
-  // Get the first text node inside this block
-  const firstTextEntry = Node.first(editor, [selection.anchor.path[0], selection.anchor.path[1]])
+  // Find the first text descendant of the block containing the cursor.
+  // The block is the parent of the current text node; walking up from
+  // selection.anchor.path keeps this correct at any nesting depth.
+  const blockPath = Path.parent(anchor.path)
+  const firstTextEntry = Node.first(editor, blockPath)
   if (!firstTextEntry) {
     return false
   }

--- a/tests/LocalizedQuotationMarks/consume.test.ts
+++ b/tests/LocalizedQuotationMarks/consume.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import { createEditor, type Editor, type Descendant, type Path, Node } from 'slate'
+import { consume } from '../../lib/LocalizedQuotationMarks/lib/consume'
+
+// Build a minimal editor shaped enough for the consume function. It only
+// reads `editor.lang` plus standard Slate APIs, so a plain createEditor()
+// with the lang field tacked on is sufficient.
+function makeEditor(content: Descendant[], lang = 'en'): Editor & { lang: string } {
+  const editor = createEditor() as Editor & { lang: string }
+  editor.lang = lang
+  editor.children = content
+  return editor
+}
+
+function textAt(editor: Editor, path: Path): string {
+  const node = Node.get(editor, path)
+  return 'text' in node ? node.text : ''
+}
+
+const quoteInput = { type: 'text/plain', data: '"', source: '' }
+
+// Slate's TypeScript types are augmented by @ttab/textbit at runtime
+// (CustomTypes), but the tests construct minimal element shapes that
+// don't carry every required field. The casts keep these focused on
+// behaviour rather than typing.
+type AnyNode = Descendant
+
+function leaf(text: string): AnyNode {
+  return { text } as AnyNode
+}
+
+function textBlock(children: AnyNode[]): AnyNode {
+  return { type: 'core/text', class: 'text', children } as AnyNode
+}
+
+function factbox(title: string, body: AnyNode[]): AnyNode {
+  return {
+    type: 'core/factbox',
+    class: 'block',
+    children: [
+      { type: 'core/factbox/title', class: 'text', children: [leaf(title)] } as AnyNode,
+      { type: 'core/factbox/body', class: 'block', children: body } as AnyNode
+    ]
+  } as AnyNode
+}
+
+describe('LocalizedQuotationMarks consume - quote conversion at varying depths', () => {
+  it('depth 2: paragraph in an article', async () => {
+    // [0]: paragraph
+    //   [0, 0]: text leaf "a \"quote here"
+    const editor = makeEditor([
+      textBlock([leaf('a "quote here')])
+    ])
+    editor.selection = {
+      anchor: { path: [0, 0], offset: 13 },
+      focus: { path: [0, 0], offset: 13 }
+    }
+
+    const result = await consume({ editor, input: quoteInput })
+
+    expect(textAt(editor, [0, 0])).toBe('a “quote here')
+    expect(result).toEqual({ type: 'text/plain', data: '”', source: '' })
+  })
+
+  it('depth 4: factbox embedded in an article - regression', async () => {
+    // [0]: factbox
+    //   [0, 0]: title
+    //   [0, 1]: body
+    //     [0, 1, 0]: paragraph
+    //       [0, 1, 0, 0]: text leaf "a \"quote in factbox"
+    const editor = makeEditor([
+      factbox('Title', [textBlock([leaf('a "quote in factbox')])])
+    ])
+    editor.selection = {
+      anchor: { path: [0, 1, 0, 0], offset: 19 },
+      focus: { path: [0, 1, 0, 0], offset: 19 }
+    }
+
+    const result = await consume({ editor, input: quoteInput })
+
+    expect(textAt(editor, [0, 1, 0, 0])).toBe('a “quote in factbox')
+    expect(result).toEqual({ type: 'text/plain', data: '”', source: '' })
+  })
+
+  it('depth 6: hypothetical deeper nesting still resolves siblings correctly', async () => {
+    // Wrap the factbox-body paragraph in two extra block layers, putting
+    // the text leaf at path length 6. The matcher should still find the
+    // earlier straight quote by walking the parent block's siblings.
+    const outerWrapper = {
+      type: 'wrapper/outer',
+      class: 'block',
+      children: [
+        {
+          type: 'wrapper/inner',
+          class: 'block',
+          children: [
+            factbox('Title', [textBlock([leaf('a "quote deeper still')])])
+          ]
+        } as AnyNode
+      ]
+    } as AnyNode
+
+    const editor = makeEditor([outerWrapper])
+    // path: [0=outer, 0=inner, 0=factbox, 1=body, 0=paragraph, 0=leaf]
+    editor.selection = {
+      anchor: { path: [0, 0, 0, 1, 0, 0], offset: 21 },
+      focus: { path: [0, 0, 0, 1, 0, 0], offset: 21 }
+    }
+
+    const result = await consume({ editor, input: quoteInput })
+
+    expect(textAt(editor, [0, 0, 0, 1, 0, 0])).toBe('a “quote deeper still')
+    expect(result).toEqual({ type: 'text/plain', data: '”', source: '' })
+  })
+})


### PR DESCRIPTION
The consume function hard-coded depth-2 paths ([block, text]) when walking sibling text leaves to find a matching previous quote. For text inside a factbox embedded in an article the cursor lives at a deeper path, e.g. [factboxIdx, bodyChildIdx, paragraphIdx, textIdx]; at that depth Editor.node(editor, [basePos, pos]) resolved to the factbox's title/body elements, never a text leaf, so the matcher bailed and the straight quote went through unchanged.

Walk siblings relative to Path.parent(selection.anchor.path) instead, which gives the same behaviour at depth 2 and works at any nesting.

Apply the same fix to isFirstCharacterOfFirstChild, which had the same depth-2 assumption and was also incidentally treating the start of any text leaf as the start of its block.