### PR TITLE
fix(image,ttvisual): align Foto row with Text row

### DIFF
--- a/lib/Image/components/FigureByline.tsx
+++ b/lib/Image/components/FigureByline.tsx
@@ -4,14 +4,11 @@ export const FigureByline = ({ children, options }: TBComponentProps) => {
   const { bylineLabel } = options as { bylineLabel?: string }
 
   return (
-    <div className='flex items-center ps-6 bg-slate-100 dark:bg-slate-800 text-sm py-0.5'>
-      <label contentEditable={false} className='w-12 opacity-60'>
+    <div className='p-2 flex rounded-xs text-sm bg-slate-100 dark:bg-slate-700'>
+      <label className='shrink-0 w-16 opacity-70' contentEditable={false}>
         {`${bylineLabel ?? 'Photo'}:`}
       </label>
-
-      <figcaption className='p-1'>
-        {children}
-      </figcaption>
+      <figcaption className='grow'>{children}</figcaption>
     </div>
   )
 }

--- a/lib/Image/components/FigureText.tsx
+++ b/lib/Image/components/FigureText.tsx
@@ -3,8 +3,8 @@ import type { TBComponentProps } from '@ttab/textbit'
 export const FigureText = ({ children, options }: TBComponentProps) => {
   const { captionLabel } = options as { captionLabel?: string }
 
-  return <div className="p-2 flex rounded rounded-xs text-sm bg-slate-200 dark:bg-slate-800">
-    <label className="grow-0 w-16 opacity-70" contentEditable={false}>{`${captionLabel ?? 'Text'}:`}</label >
+  return <div className="p-2 flex rounded-xs text-sm bg-slate-200 dark:bg-slate-800">
+    <label className="shrink-0 w-16 opacity-70" contentEditable={false}>{`${captionLabel ?? 'Text'}:`}</label >
     <figcaption className="grow">{children}</figcaption>
   </div >
 }

--- a/lib/TTVisual/components/TTVisualByline.tsx
+++ b/lib/TTVisual/components/TTVisualByline.tsx
@@ -4,14 +4,11 @@ export const TTVisualByline = ({ children, options }: TBComponentProps) => {
   const { bylineLabel } = options as { bylineLabel?: string }
 
   return (
-    <div className='flex items-center ps-6 bg-slate-100 dark:bg-slate-800 text-sm py-0.5'>
-      <label contentEditable={false} className='w-12 opacity-60'>
+    <div className='p-2 flex rounded-xs text-sm bg-slate-100 dark:bg-slate-700'>
+      <label className='shrink-0 w-16 opacity-70' contentEditable={false}>
         {`${bylineLabel ?? 'Photo'}:`}
       </label>
-
-      <figcaption className='p-1'>
-        {children}
-      </figcaption>
+      <figcaption className='grow'>{children}</figcaption>
     </div>
   )
 }

--- a/lib/TTVisual/components/TTVisualText.tsx
+++ b/lib/TTVisual/components/TTVisualText.tsx
@@ -4,14 +4,11 @@ export const TTVisualText = ({ children, options }: TBComponentProps) => {
   const { captionLabel } = options as { captionLabel?: string }
 
   return (
-    <div className='flex items-center ps-6 bg-slate-100 dark:bg-slate-800 text-sm py-0.5'>
-      <label contentEditable={false} className='w-12 opacity-60'>
+    <div className='p-2 flex rounded-xs text-sm bg-slate-200 dark:bg-slate-800'>
+      <label className='shrink-0 w-16 opacity-70' contentEditable={false}>
         {`${captionLabel ?? 'Text'}:`}
       </label>
-
-      <figcaption className='p-1'>
-        {children}
-      </figcaption>
+      <figcaption className='grow'>{children}</figcaption>
     </div>
   )
 }

--- a/tests/Image/FigureAlignment.test.tsx
+++ b/tests/Image/FigureAlignment.test.tsx
@@ -1,0 +1,88 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { FigureText } from '../../lib/Image/components/FigureText'
+import { FigureByline } from '../../lib/Image/components/FigureByline'
+import type { TBComponentProps } from '@ttab/textbit'
+import type { Editor } from 'slate'
+
+const makeProps = (children: string): TBComponentProps => ({
+  editor: {} as Editor,
+  children: [children],
+  element: {
+    type: 'core/image/text',
+    id: '00000000-0000-0000-0000-000000000000',
+    class: 'text',
+    children: [{ text: children }]
+  }
+})
+
+const wrapper = (container: HTMLElement) => {
+  const el = container.firstElementChild
+  if (!(el instanceof HTMLElement)) throw new Error('expected wrapper element')
+  return el
+}
+
+const LAYOUT_PATTERNS = [
+  /^-?(p|px|py|pt|pr|pb|pl|ps|pe|m|mx|my|mt|mr|mb|ml|ms|me)-/,
+  /^(flex|grid|items|justify|content|self|place|order|gap)(-|$)/,
+  /^(grow|shrink|basis)(-|$)/,
+  /^space-[xy]-/,
+  /^rounded(-|$)/,
+  /^text-/
+]
+
+const layoutClasses = (el: HTMLElement) =>
+  Array.from(el.classList).filter((c) => LAYOUT_PATTERNS.some((re) => re.test(c))).sort()
+
+const classList = (el: Element) => Array.from(el.classList).sort()
+
+describe('Image plugin: Text and Foto rows align', () => {
+  it('Text and Foto wrappers share the same horizontal/vertical layout classes', () => {
+    const text = render(<FigureText {...makeProps('caption body')} options={{}} />)
+    const byline = render(<FigureByline {...makeProps('byline body')} options={{}} />)
+
+    expect(layoutClasses(wrapper(text.container))).toEqual(layoutClasses(wrapper(byline.container)))
+  })
+
+  it('Text and Foto labels render identically', () => {
+    const text = render(<FigureText {...makeProps('x')} options={{}} />)
+    const byline = render(<FigureByline {...makeProps('x')} options={{}} />)
+
+    const textLabel = text.container.querySelector('label')
+    const bylineLabel = byline.container.querySelector('label')
+    if (!textLabel) throw new Error('FigureText has no label')
+    if (!bylineLabel) throw new Error('FigureByline has no label')
+
+    expect(classList(textLabel)).toEqual(classList(bylineLabel))
+    expect(textLabel.getAttribute('contenteditable')).toBe('false')
+    expect(bylineLabel.getAttribute('contenteditable')).toBe('false')
+  })
+
+  it('Text and Foto figcaptions render identically', () => {
+    const text = render(<FigureText {...makeProps('x')} options={{}} />)
+    const byline = render(<FigureByline {...makeProps('x')} options={{}} />)
+
+    const textCap = text.container.querySelector('figcaption')
+    const bylineCap = byline.container.querySelector('figcaption')
+    if (!textCap) throw new Error('FigureText has no figcaption')
+    if (!bylineCap) throw new Error('FigureByline has no figcaption')
+
+    expect(classList(textCap)).toEqual(classList(bylineCap))
+  })
+
+  it('Foto row honours bylineLabel, defaulting to "Photo:"', () => {
+    const def = render(<FigureByline {...makeProps('x')} options={{}} />)
+    expect(def.container.textContent).toContain('Photo:')
+
+    const custom = render(<FigureByline {...makeProps('x')} options={{ bylineLabel: 'Foto' }} />)
+    expect(custom.container.textContent).toContain('Foto:')
+  })
+
+  it('Text row honours captionLabel, defaulting to "Text:"', () => {
+    const def = render(<FigureText {...makeProps('x')} options={{}} />)
+    expect(def.container.textContent).toContain('Text:')
+
+    const custom = render(<FigureText {...makeProps('x')} options={{ captionLabel: 'Bildtext' }} />)
+    expect(custom.container.textContent).toContain('Bildtext:')
+  })
+})


### PR DESCRIPTION
FigureByline used a different set of utility classes from FigureText: ps-6 vs p-2, w-12 vs w-16, opacity-60 vs opacity-70, figcaption p-1 vs grow. The 24px inline-start padding on Foto pushed its label past the Text label, creating the "blank space at start" reported in the screenshot. Match FigureByline's layout classes to FigureText, keeping the background tint as the only differentiator.

The label's flex sizing also needed fixing: `grow-0` only blocks growth, not shrinkage, so with a long figcaption the `w-16` label would shrink to fit its content, mis-aligning Text and Foto. Use `shrink-0` instead.

Apply the same layout (and shrink-0) to TTVisualText/TTVisualByline so tt/visual blocks render with the same alignment as core/image.

Tests: tighten the layoutClasses regex (require a trailing `-` on padding/margin prefixes; cover negative margins, space-x/y, flex sizing) and assert full sorted classList equality on labels and figcaptions so divergences like opacity-60 vs opacity-70 are caught. Drop the dead slate-react mock and replace if-return narrowing with explicit throw guards. Fix latent tsc error: caption/byline sub-elements are class: 'text' with type 'core/image/text', not class: 'image'.

Refs ELELOG-333