### PR TITLE
Add correct language mappings for nb and nn alongside with the generi…

### DIFF
--- a/lib/LocalizedQuotationMarks/lib/consume.ts
+++ b/lib/LocalizedQuotationMarks/lib/consume.ts
@@ -17,6 +17,12 @@ const LOCALIZED_QUOTES: Record<string, string[]>  = {
   no: [
     '‹', '›',
     '«', '»'],
+  nb: [
+    '‹', '›',
+    '«', '»'],
+  nn: [
+    '‹', '›',
+    '«', '»'],
   en: [
     '‘', '’',
     '“', '”'],


### PR DESCRIPTION
…c no. The mappings for the specific bokmål and nynorsk was missing. Leaving the generic Norwegian macro language code as well.